### PR TITLE
fix: extract 4-digit episode numbers correctly

### DIFF
--- a/src/articleListings.tsx
+++ b/src/articleListings.tsx
@@ -375,7 +375,7 @@ export class Listing extends BaseListing<ListingProps, ListingState> {
 				});
 				return;
 			}
-			const number = url.substr(url.length - 4, 3);
+			const number = url.substr(url.length - 5, 4);
 
 			const maxPosition = this.state.news.reduce(
 				(n, a) => Math.max(n, a.position),


### PR DESCRIPTION
Since 1000's episode the episode number is extracted incorrectly for news.radio-t
Here is the link containing the error https://news.radio-t.com/post/temy-slushatelei-003
It should be https://news.radio-t.com/post/temy-slushatelei-1003

Will fix previous 4 episodes pages and their urls if you want me to, for consistency purposes

