### PR TITLE
Fix url reported after adding an article automatically

### DIFF
--- a/src/add.spec.tsx
+++ b/src/add.spec.tsx
@@ -1,0 +1,32 @@
+import { mount } from "enzyme";
+
+import * as API from "./api";
+import AddArticleForm from "./add";
+import { sleep } from "./utils";
+
+jest.mock("./api");
+jest.mock("./notifications");
+
+describe("AddArticleForm", () => {
+	test("reports the url it submitted in automatic mode", async () => {
+		(API.addArticle as any).mockImplementation(async () => null);
+		const onAdd = jest.fn();
+		const link = "https://example.com/news/1";
+		const container = document.createElement("div");
+		document.body.appendChild(container);
+		mount(<AddArticleForm onAdd={onAdd} />, { attachTo: container });
+
+		const input = container.querySelector(
+			".add-form__article-url"
+		) as HTMLInputElement;
+		input.value = link;
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+		const form = container.querySelector("form") as HTMLFormElement;
+		form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+		await sleep(100);
+
+		expect(API.addArticle).toBeCalledWith(link);
+		expect(onAdd).toBeCalledWith(link);
+		(API.addArticle as any).mockClear();
+	});
+});

--- a/src/add.tsx
+++ b/src/add.tsx
@@ -307,7 +307,7 @@ export default class AddArticleForm extends Component<Props, State> {
 	}
 	protected async onSubmit() {
 		this.setState({ posting: true });
-		const url = this.state.manualLink;
+		const url = this.state.manual ? this.state.manualLink : this.state.autolink;
 		try {
 			if (!this.state.manual) {
 				await addArticle(this.state.autolink);

--- a/src/articleListings.tsx
+++ b/src/articleListings.tsx
@@ -505,7 +505,7 @@ export class Listing extends BaseListing<ListingProps, ListingState> {
 							style={{
 								display: this.state.addFormExpanded ? "" : "none",
 							}}
-							onAdd={async url => {
+							onAdd={url => {
 								retry(async () => {
 									await sleep(2000);
 									await this.update(true);
@@ -515,7 +515,7 @@ export class Listing extends BaseListing<ListingProps, ListingState> {
 									);
 									if (article === null)
 										throw new Error("Added article is not found");
-								}, 5);
+								}, 5).catch(e => console.error(e));
 							}}
 						/>
 					</div>


### PR DESCRIPTION
[`AddArticleForm.onSubmit`](https://github.com/radio-t/rtnews-ui/blob/b45fdf44a9c961c2ceb8e976563f3c9244947787/src/add.tsx#L310) captured `manualLink` before deciding which form was submitted, so an article added through the automatic form was posted with `autolink` but reported to `onAdd` with the manual field, which is empty in that mode. The [listing](https://github.com/radio-t/rtnews-ui/blob/b45fdf44a9c961c2ceb8e976563f3c9244947787/src/articleListings.tsx#L508) then reloaded the news five times over roughly ten seconds looking for an article whose `origlink` equals an empty string, and finished with a rejected promise nobody handled. The article itself was added, so the only visible traces were the delay and the console error.

After this change the url passed to `onAdd` is the one the form actually submitted, and the retry loop in the listing logs its failure instead of leaving a rejected promise behind.

The new test in `src/add.spec.tsx` submits the automatic form and asserts that `addArticle` and `onAdd` receive the same url; against the previous code it fails with an empty string.
