### PR TITLE
Fix compose file name in docker make targets

### DIFF
--- a/makefile
+++ b/makefile
@@ -33,33 +33,33 @@ test:
 
 .PHONY: dockerBuild
 dockerBuild:
-	docker compose -f docker compose.dev.yml build
+	docker compose -f docker-compose.dev.yml build
 
 # usefull after changing dependencies in package.json
 .PHONY: dockerClear
 dockerClear:
-	docker compose -f docker compose.dev.yml down --rmi all
+	docker compose -f docker-compose.dev.yml down --rmi all
 
 # usefull when want to test/add/remove new dependencies
 .PHONY: dockerShell
 dockerShell:
-	docker compose -f docker compose.dev.yml run --rm -p "127.0.0.1:9000:9000" builder
+	docker compose -f docker-compose.dev.yml run --rm -p "127.0.0.1:9000:9000" builder
 
 # builds "public" directory
 .PHONY: dockerBuildPublic
 dockerBuildPublic:
-	docker compose -f docker compose.dev.yml run --rm builder -c "make build"
+	docker compose -f docker-compose.dev.yml run --rm builder -c "make build"
 
 # binds to 127.0.0.1:9000
 .PHONY: dockerDevServer
 dockerDevServer:
-	docker compose -f docker compose.dev.yml run --rm -p "127.0.0.1:9000:9000" builder -c "make devServerWithRemote"
+	docker compose -f docker-compose.dev.yml run --rm -p "127.0.0.1:9000:9000" builder -c "make devServerWithRemote"
 
 # binds to 0.0.0.0:9000
 .PHONY: dockerDevServerWithRemote
 dockerDevServerWithRemote:
-	docker compose -f docker compose.dev.yml run --rm -p "0.0.0.0:9000:9000" builder -c "make devServerWithRemote"
+	docker compose -f docker-compose.dev.yml run --rm -p "0.0.0.0:9000:9000" builder -c "make devServerWithRemote"
 
 .PHONY: dockerTest
 dockerTest:
-	docker compose -f docker compose.dev.yml run --rm builder -c "make test"
+	docker compose -f docker-compose.dev.yml run --rm builder -c "make test"


### PR DESCRIPTION
Commit [d939a32](https://github.com/radio-t/rtnews-ui/commit/d939a3280cf42d4efd66d4a73b70d8175817be9a) replaced `docker-compose` with `docker compose` everywhere in the makefile, and the replacement also rewrote the file name in the `-f` argument, so all seven docker targets have been calling `-f docker compose.dev.yml` since then and fail on a file that does not exist.

After this change they point at `docker-compose.dev.yml` again, which is the name of the file in the repository.
