### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: build
+
+on:
+  push:
+    branches: ["**"]
+    tags: ["**"]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+
+      - name: set up node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: install dependencies
+        run: npm ci
+
+      - name: test
+        run: ./node_modules/.bin/jest --verbose
+
+      - name: build
+        run: ./node_modules/.bin/webpack --mode production

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # rtnews-ui - Клиентская сторона для новой версии news.radio-t.com
 
+[![build](https://github.com/radio-t/rtnews-ui/actions/workflows/ci.yml/badge.svg)](https://github.com/radio-t/rtnews-ui/actions/workflows/ci.yml)
+
 Полное описание задачи можно [подсмотреть здесь](http://p.umputun.com/2015/11/26/vsiem-mirom-dlia-obshchiei-polzy/)
 
 ----


### PR DESCRIPTION
Nothing ran the tests or the build on push, so a commit that breaks either of them only surfaced when somebody built the project locally.

The workflow installs from the lock file, runs jest and builds with webpack, on every branch, every tag and every pull request, with a read only token.

It needs #122 to go in first: on master `npm ci` fails while building node-sass, which has no binaries for any node newer than 13, so this workflow stays red until then.
